### PR TITLE
Improvements: Hide controls while playing videos.

### DIFF
--- a/Classes/IDMPhotoBrowser.m
+++ b/Classes/IDMPhotoBrowser.m
@@ -766,8 +766,7 @@ NSLocalizedStringFromTableInBundle((key), nil, [NSBundle bundleWithPath:[[NSBund
     [_panGesture setMinimumNumberOfTouches:1];
     [_panGesture setMaximumNumberOfTouches:1];
 
-    // Update
-    //[self reloadData];
+    [self hideControlsByDefaultIfNeeded];
 
 	// Super
     [super viewDidLoad];
@@ -1424,6 +1423,13 @@ NSLocalizedStringFromTableInBundle((key), nil, [NSBundle bundleWithPath:[[NSBund
 		[self setControlsHidden:YES animated:YES permanent:NO];
 	}
 }
+
+- (void)hideControlsByDefaultIfNeeded {
+    if ([self photoAtIndex:_currentPageIndex].type == kMediaTypeVideo) {
+        [self setControlsHidden:YES animated:NO permanent:NO];
+    }
+}
+
 - (void)handleSingleTap:(IDMPhoto *)media {
     if (_dismissOnTouch) {
         [self doneButtonPressed:nil];
@@ -1575,7 +1581,7 @@ NSLocalizedStringFromTableInBundle((key), nil, [NSBundle bundleWithPath:[[NSBund
                                animated:YES];
     }
 
-    // Keep controls hidden
+    // Keep controls unhidden
     [self setControlsHidden:NO animated:YES permanent:YES];
 }
 


### PR DESCRIPTION
Videos are handled as video streaming, which is something like url = "https://dev1.spond.dev/storage/video/A18DBACD9676452C656A82BB12F6BA48/stream.m3u8".

Share it via Slack, WeChat, it would actually be open / download as a txt file with content as:

/storage/video/A18DBACD9676452C656A82BB12F6BA48/stream_1.m3u8 /storage/video/A18DBACD9676452C656A82BB12F6BA48/stream_2.m3u8 /storage/video/A18DBACD9676452C656A82BB12F6BA48/stream_3.m3u8

In other words, which is actually not something meaningful to be shared. As a result, we dicided to hide controls(Share button, etc.) while playing videos.