### PR TITLE
Fix file:// video playback on newer IOS (use AVAsset + URL helper).

### DIFF
--- a/Classes/IDMPhoto.h
+++ b/Classes/IDMPhoto.h
@@ -24,6 +24,7 @@ typedef void (^IDMProgressUpdateBlock)(CGFloat progress);
 @property (nonatomic, strong) NSString *caption;
 @property (nonatomic, strong) NSURL *photoURL;
 @property (nonatomic, strong) NSURL *videoURL;
+@property (nonatomic, strong) AVAsset *videoAsset;
 @property (nonatomic, strong) UIImage *videoThumbnail;
 @property (nonatomic, strong) NSURL *videoThumbnailURL;
 @property (nonatomic, readonly) NSString *vastTag; // Optional vast ad tag for video.

--- a/Classes/IDMPhoto.m
+++ b/Classes/IDMPhoto.m
@@ -38,6 +38,7 @@
 @synthesize underlyingImage = _underlyingImage, 
 photoURL = _photoURL,
 videoURL = _videoURL,
+videoAsset = _videoAsset,
 vastTag = _vastTag,
 adPlayType = _adPlayType,
 caption = _caption,

--- a/Classes/IDMPhotoProtocol.h
+++ b/Classes/IDMPhotoProtocol.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <AVFoundation/AVFoundation.h>
 #import "IDMPBConstants.h"
 
 // Name of notification used when a photo has completed loading process
@@ -81,5 +82,9 @@ typedef NS_ENUM(NSUInteger, IDMVASTAdPlayType) {
 - (UIImage *)placeholderImage;
 
 - (UIImage *)failureIcon;
+
+// Optional local asset fallback for video playback.
+// When present, browser uses this AVAsset directly instead of creating a player from videoURL.
+- (AVAsset *)videoAsset;
 
 @end

--- a/Classes/IDMUtils.h
+++ b/Classes/IDMUtils.h
@@ -6,7 +6,19 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <AVFoundation/AVFoundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
 
 @interface IDMUtils : NSObject
+
 + (CGRect)adjustRect:(CGRect)rect forSafeAreaInsets:(UIEdgeInsets)insets forBounds:(CGRect)bounds adjustForStatusBar:(BOOL)adjust statusBarHeight:(int)statusBarHeight;
+
+/// Returns an `AVPlayer` for the given video URL. For `file://` URLs (e.g. Photo Library), uses
+/// `AVURLAsset` + `AVPlayerItem` instead of `+[AVPlayer playerWithURL:]`, which can fail for some
+/// local paths on newer iOS. Non-file URLs use `+[AVPlayer playerWithURL:]`.
++ (nullable AVPlayer *)playerForVideoURL:(nullable NSURL *)url;
+
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Classes/IDMUtils.m
+++ b/Classes/IDMUtils.m
@@ -6,8 +6,31 @@
 //
 
 #import "IDMUtils.h"
+#import <AVFoundation/AVFoundation.h>
 
 @implementation IDMUtils
+
++ (AVPlayer *)playerForVideoURL:(NSURL *)url {
+    if (url == nil) {
+        return nil;
+    }
+    if (url.isFileURL) {
+        NSURL *resolvedURL = url;
+        if (url.fragment.length > 0 || url.query.length > 0) {
+            NSURLComponents *components = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:NO];
+            components.fragment = nil;
+            components.query = nil;
+            if (components.URL != nil) {
+                resolvedURL = components.URL;
+            }
+        }
+        AVURLAsset *asset = [AVURLAsset URLAssetWithURL:resolvedURL options:nil];
+        AVPlayerItem *item = [AVPlayerItem playerItemWithAsset:asset];
+        return [AVPlayer playerWithPlayerItem:item];
+    }
+    return [AVPlayer playerWithURL:url];
+}
+
 /**
  * Adjust a rect to be moved into a safe area specified by `insets`.
  *

--- a/Classes/IDMZoomingScrollView.m
+++ b/Classes/IDMZoomingScrollView.m
@@ -9,6 +9,7 @@
 #import "IDMZoomingScrollView.h"
 #import "IDMPhotoBrowser.h"
 #import "IDMPhoto.h"
+#import "IDMUtils.h"
 #import <SDWebImage/SDWebImage.h>
 
 @import GoogleInteractiveMediaAds;
@@ -305,7 +306,20 @@ captionView = _captionView;
                                                  name:UIApplicationDidBecomeActiveNotification
                                                object:nil];
 
-    AVPlayer *player = [AVPlayer playerWithURL:_photo.videoURL];
+    AVPlayer *player = nil;
+    AVAsset *videoAsset = nil;
+    if ([_photo respondsToSelector:@selector(videoAsset)]) {
+        videoAsset = [_photo videoAsset];
+    }
+    if (videoAsset != nil) {
+        AVPlayerItem *item = [AVPlayerItem playerItemWithAsset:videoAsset];
+        player = [AVPlayer playerWithPlayerItem:item];
+    } else {
+        player = [IDMUtils playerForVideoURL:_photo.videoURL];
+    }
+    if (player == nil) {
+        return;
+    }
     [player addObserver:self
              forKeyPath:@"timeControlStatus"
                 options:NSKeyValueObservingOptionNew


### PR DESCRIPTION
Problem:
On newer iOS, playing some user-selected Photo Library videos from a cached file:// URL (IDMPhoto.videoURL + AVPlayer from URL) can fail, even when the URL string looks valid.

Approach:
Primary path: optional videoAsset on IDMPhoto / IDMPhotoProtocol. When set, IDMZoomingScrollView builds the player with AVPlayerItem + AVAsset (same class of fix as using PHImageManager / requestAVAsset). Fallback path: when only a URL is available, [IDMUtils playerForVideoURL:] builds the player: for file:// URLs, strip query/fragment when needed and use AVURLAsset + AVPlayerItem instead of +[AVPlayer playerWithURL:]; non-file URLs keep playerWithURL:.