### PR TITLE
Pod: Pin podspec dependency versions to stop Podfile.lock checksum churn.

### DIFF
--- a/IDMPhotoBrowser.podspec
+++ b/IDMPhotoBrowser.podspec
@@ -11,8 +11,8 @@ Pod::Spec.new do |s|
   s.resources     =  'Classes/IDMPhotoBrowser.bundle', 'Classes/IDMPBLocalizations.bundle'
   s.framework     =  'MessageUI', 'QuartzCore', 'SystemConfiguration', 'MobileCoreServices', 'Security'
   s.requires_arc  =  true
-  s.dependency       'SDWebImage'
-  s.dependency       'DACircularProgress'
-  s.dependency       'pop'
-  s.dependency       'GoogleAds-IMA-iOS-SDK'
+  s.dependency       'SDWebImage', '>= 5.0'
+  s.dependency       'DACircularProgress', '>= 2.3'
+  s.dependency       'pop', '>= 1.0'
+  s.dependency       'GoogleAds-IMA-iOS-SDK', '>= 3.0'
   end


### PR DESCRIPTION
## Summary
- Add minimum version requirements to all four bare `s.dependency` declarations in `IDMPhotoBrowser.podspec`.
- This makes the CocoaPods-generated local podspec JSON contain no empty arrays, so `SPEC CHECKSUMS` for `IDMPhotoBrowser` is identical across json gem ≤2.7 and ≥2.8.

## Floors (compatible with current spond-ios resolutions)
| Dependency | Pin | Currently resolved |
|---|---|---|
| SDWebImage | `>= 5.0` | 5.21.7 |
| DACircularProgress | `>= 2.3` | 2.3.1 |
| pop | `>= 1.0` | 1.0.12 |
| GoogleAds-IMA-iOS-SDK | `>= 3.0` | 3.31.0 |

## Follow-up (spond-ios)
After this merges to `master`, bump the `:commit` pin for `IDMPhotoBrowser` in the spond-ios `Podfile` and run `pod install` for the one-time deterministic checksum flip.

## Test plan
- [ ] Merge this PR to `master`
- [ ] In spond-ios, point `pod 'IDMPhotoBrowser'` at the new commit and run `pod install`
- [ ] Wipe `Pods/` and re-run `pod install` — `Podfile.lock` must show zero diff
- [ ] Confirm resolved versions are unchanged (SDWebImage 5.21.7, DACircularProgress 2.3.1, pop 1.0.12, GoogleAds-IMA-iOS-SDK 3.31.0)